### PR TITLE
Remove classes from svg logo

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196.32 170.02"><defs><style>.cls-1{fill:#42b883;}.cls-2{fill:#35495e;}</style></defs><title>logo</title><polygon class="cls-1" points="120.83 0 98.16 39.26 75.49 0 0 0 98.16 170.02 196.32 0 120.83 0"/><polygon class="cls-2" points="120.83 0 98.16 39.26 75.49 0 39.26 0 98.16 102.01 157.06 0 120.83 0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196.32 170.02">
+  <path fill="#42b883" d="M120.83 0L98.16 39.26 75.49 0H0l98.16 170.02L196.32 0h-75.49z"/>
+  <path fill="#35495e" d="M120.83 0L98.16 39.26 75.49 0H39.26l58.9 102.01L157.06 0h-36.23z"/>
+</svg>


### PR DESCRIPTION
`.cls-1` and `.cls-2` might be overwritten by other svgs on the same page. So it is safer to use inline `fill` attributes.